### PR TITLE
Fix charset issue in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ insert_final_newline = true
 # Matches multiple files with brace expansion notation
 # Set default charset
 [*.{h,hpp,cpp}]
-charset = utf8
+charset = utf-8
 
 # 4 space indentation
 indent_style = space


### PR DESCRIPTION
`charset` 的值应该是 `utf-8`，参考的是 https://editorconfig.org